### PR TITLE
Applying the 'opens in a window or tab' hidden link consistently with a space inside the span than outside.

### DIFF
--- a/openacr/Moodle-3.html
+++ b/openacr/Moodle-3.html
@@ -195,9 +195,10 @@
               <tr>
                 <td>
                   <a href="https://www.w3.org/TR/WCAG20/" target="_blank"
-                    >Web Content Accessibility Guidelines 2.0
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    >Web Content Accessibility Guidelines 2.0<span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -213,9 +214,8 @@
                 <td>
                   <a href="https://www.access-board.gov/ict/" target="_blank"
                     >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -329,9 +329,8 @@
                   href="https://www.w3.org/TR/WCAG20/#text-equiv-all"
                   target="_blank"
                 >
-                  1.1.1 Non-text Content
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -373,9 +372,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt"
                   target="_blank"
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -430,9 +430,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-captions"
                   target="_blank"
                 >
-                  1.2.2 Captions (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -484,9 +483,9 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc"
                   target="_blank"
                 >
-                  1.2.3 Audio Description or Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -538,9 +537,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
                   target="_blank"
                 >
-                  1.3.1 Info and Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -582,9 +580,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
                   target="_blank"
                 >
-                  1.3.2 Meaningful Sequence
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -626,9 +623,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
                   target="_blank"
                 >
-                  1.3.3 Sensory Characteristics
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -683,9 +679,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
                   target="_blank"
                 >
-                  1.4.1 Use of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -727,9 +722,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
                   target="_blank"
                 >
-                  1.4.2 Audio Control
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -783,9 +777,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
                   target="_blank"
                 >
-                  2.1.1 Keyboard
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -827,9 +820,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
                   target="_blank"
                 >
-                  2.1.2 No Keyboard Trap
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -871,9 +863,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
                   target="_blank"
                 >
-                  2.2.1 Pause, Stop, Hide
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.1 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -926,9 +917,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-pause"
                   target="_blank"
                 >
-                  2.2.2 Timing Adjustable
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.2 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -980,9 +970,10 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate"
                   target="_blank"
                 >
-                  2.3.1 Three Flashes or Below Threshold
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1024,9 +1015,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
                   target="_blank"
                 >
-                  2.4.1 Bypass Blocks
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1080,9 +1070,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
                   target="_blank"
                 >
-                  2.4.2 Page Titled
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1124,9 +1113,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
                   target="_blank"
                 >
-                  2.4.3 Focus Order
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1168,9 +1156,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
                   target="_blank"
                 >
-                  2.4.4 Link Purpose (In Context)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1212,9 +1199,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id"
                   target="_blank"
                 >
-                  3.1.1 Language of Page
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1256,9 +1242,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
                   target="_blank"
                 >
-                  3.2.1 On Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1300,9 +1285,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
                   target="_blank"
                 >
-                  3.2.2 On Input
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1344,9 +1328,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-identified"
                   target="_blank"
                 >
-                  3.3.1 Error Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1388,9 +1371,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-cues"
                   target="_blank"
                 >
-                  3.3.2 Labels or Instructions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1432,9 +1414,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses"
                   target="_blank"
                 >
-                  4.1.1 Parsing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1476,9 +1457,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv"
                   target="_blank"
                 >
-                  4.1.2 Name, Role, Value
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1559,9 +1539,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
                   target="_blank"
                 >
-                  1.2.4 Captions (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1607,9 +1586,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
                   target="_blank"
                 >
-                  1.2.5 Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1662,9 +1642,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
                   target="_blank"
                 >
-                  1.4.3 Contrast (Minimum)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1718,9 +1697,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
                   target="_blank"
                 >
-                  1.4.4 Resize text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1756,9 +1734,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
                   target="_blank"
                 >
-                  1.4.5 Images of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1800,9 +1777,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
                   target="_blank"
                 >
-                  2.4.5 Multiple Ways
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1844,9 +1820,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
                   target="_blank"
                 >
-                  2.4.6 Headings and Labels
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1888,9 +1863,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
                   target="_blank"
                 >
-                  2.4.7 Focus Visible
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1932,9 +1906,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id"
                   target="_blank"
                 >
-                  3.1.2 Language of Parts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1976,9 +1949,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
                   target="_blank"
                 >
-                  3.2.3 Consistent Navigation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2014,9 +1986,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
                   target="_blank"
                 >
-                  3.2.4 Consistent Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2058,9 +2029,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
                   target="_blank"
                 >
-                  3.3.3 Error Suggestion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2102,9 +2072,10 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible"
                   target="_blank"
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2185,9 +2156,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-sign"
                   target="_blank"
                 >
-                  1.2.6 Sign Language (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.6 Sign Language (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2222,9 +2192,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad"
                   target="_blank"
                 >
-                  1.2.7 Extended Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.7 Extended Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2259,9 +2230,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc"
                   target="_blank"
                 >
-                  1.2.8 Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.8 Media Alternative (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2296,9 +2268,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only"
                   target="_blank"
                 >
-                  1.2.9 Audio-only (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.9 Audio-only (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2322,9 +2293,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7"
                   target="_blank"
                 >
-                  1.4.6 Contrast (Enhanced)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.6 Contrast (Enhanced)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2361,9 +2331,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio"
                   target="_blank"
                 >
-                  1.4.7 Low or No Background Audio
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.7 Low or No Background Audio<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2387,9 +2356,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation"
                   target="_blank"
                 >
-                  1.4.8 Visual Presentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.8 Visual Presentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2413,9 +2381,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images"
                   target="_blank"
                 >
-                  1.4.9 Images of Text (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.9 Images of Text (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2439,9 +2406,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs"
                   target="_blank"
                 >
-                  2.1.3 Keyboard (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.3 Keyboard (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2465,9 +2431,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions"
                   target="_blank"
                 >
-                  2.2.3 No Timing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.3 No Timing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2491,9 +2456,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-postponed"
                   target="_blank"
                 >
-                  2.2.4 Interruptions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.4 Interruptions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2517,9 +2481,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout"
                   target="_blank"
                 >
-                  2.2.5 Re-authenticating
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.5 Re-authenticating<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2543,9 +2506,8 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-three-times"
                   target="_blank"
                 >
-                  2.3.2 Three Flashes
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.2 Three Flashes<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2569,9 +2531,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location"
                   target="_blank"
                 >
-                  2.4.8 Location
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.8 Location<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2595,9 +2556,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link"
                   target="_blank"
                 >
-                  2.4.9 Link Purpose (Link Only)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.9 Link Purpose (Link Only)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2636,9 +2596,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings"
                   target="_blank"
                 >
-                  2.4.10 Section Headings
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.10 Section Headings<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2672,9 +2631,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-idioms"
                   target="_blank"
                 >
-                  3.1.3 Unusual Words
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.3 Unusual Words<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2698,9 +2656,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-located"
                   target="_blank"
                 >
-                  3.1.4 Abbreviations
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.4 Abbreviations<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2740,9 +2697,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-supplements"
                   target="_blank"
                 >
-                  3.1.5 Reading Level
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.5 Reading Level<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2778,9 +2734,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation"
                   target="_blank"
                 >
-                  3.1.6 Pronunciation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.6 Pronunciation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2804,9 +2759,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context"
                   target="_blank"
                 >
-                  3.2.5 Change on Request
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.5 Change on Request<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2830,9 +2784,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help"
                   target="_blank"
                 >
-                  3.3.5 Help
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.5 Help<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2867,9 +2820,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all"
                   target="_blank"
                 >
-                  3.3.6 Error Prevention (All)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.6 Error Prevention (All)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2966,9 +2918,8 @@
                   href="https://www.access-board.gov/ict/#302.1"
                   target="_blank"
                 >
-                  302.1 Without Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.1 Without Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2999,9 +2950,8 @@
                   href="https://www.access-board.gov/ict/#302.2"
                   target="_blank"
                 >
-                  302.2 With Limited Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.2 With Limited Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3028,9 +2978,8 @@
                   href="https://www.access-board.gov/ict/#302.3"
                   target="_blank"
                 >
-                  302.3 Without Perception of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.3 Without Perception of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3061,9 +3010,8 @@
                   href="https://www.access-board.gov/ict/#302.4"
                   target="_blank"
                 >
-                  302.4 Without Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.4 Without Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3085,9 +3033,8 @@
                   href="https://www.access-board.gov/ict/#302.5"
                   target="_blank"
                 >
-                  302.5 With Limited Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.5 With Limited Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3109,9 +3056,8 @@
                   href="https://www.access-board.gov/ict/#302.6"
                   target="_blank"
                 >
-                  302.6 Without Speech
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.6 Without Speech<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3133,9 +3079,8 @@
                   href="https://www.access-board.gov/ict/#302.7"
                   target="_blank"
                 >
-                  302.7 With Limited Manipulation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.7 With Limited Manipulation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3166,9 +3111,10 @@
                   href="https://www.access-board.gov/ict/#302.8"
                   target="_blank"
                 >
-                  302.8 With Limited Reach and Strength
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.8 With Limited Reach and Strength<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3195,9 +3141,9 @@
                   href="https://www.access-board.gov/ict/#302.9"
                   target="_blank"
                 >
-                  302.9 With Limited Language, Cognitive, and Learning Abilities
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.9 With Limited Language, Cognitive, and Learning
+                  Abilities<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3296,9 +3242,10 @@
                   href="https://www.access-board.gov/ict/#602.2"
                   target="_blank"
                 >
-                  602.2 Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.2 Accessibility and Compatibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3321,9 +3268,8 @@
                   target="_blank"
                 >
                   602.4 Alternate Formats for Non-Electronic Support
-                  Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  Documentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3345,9 +3291,9 @@
                   href="https://www.access-board.gov/ict/#603.2"
                   target="_blank"
                 >
-                  603.2 Information on Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.2 Information on Accessibility and Compatibility
+                  Features<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3369,9 +3315,10 @@
                   href="https://www.access-board.gov/ict/#603.3"
                   target="_blank"
                 >
-                  603.3 Accommodation of Communication Needs
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.3 Accommodation of Communication Needs<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3424,16 +3371,14 @@
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >OpenACR<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >GSA<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
             </div>

--- a/openacr/NVDA-2018.html
+++ b/openacr/NVDA-2018.html
@@ -184,9 +184,10 @@
               <tr>
                 <td>
                   <a href="https://www.w3.org/TR/WCAG20/" target="_blank"
-                    >Web Content Accessibility Guidelines 2.0
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    >Web Content Accessibility Guidelines 2.0<span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -202,9 +203,8 @@
                 <td>
                   <a href="https://www.access-board.gov/ict/" target="_blank"
                     >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -318,9 +318,8 @@
                   href="https://www.w3.org/TR/WCAG20/#text-equiv-all"
                   target="_blank"
                 >
-                  1.1.1 Non-text Content
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -362,9 +361,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt"
                   target="_blank"
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -406,9 +406,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-captions"
                   target="_blank"
                 >
-                  1.2.2 Captions (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -450,9 +449,9 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc"
                   target="_blank"
                 >
-                  1.2.3 Audio Description or Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -494,9 +493,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
                   target="_blank"
                 >
-                  1.3.1 Info and Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -538,9 +536,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
                   target="_blank"
                 >
-                  1.3.2 Meaningful Sequence
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -582,9 +579,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
                   target="_blank"
                 >
-                  1.3.3 Sensory Characteristics
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -626,9 +622,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
                   target="_blank"
                 >
-                  1.4.1 Use of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -670,9 +665,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
                   target="_blank"
                 >
-                  1.4.2 Audio Control
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -714,9 +708,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
                   target="_blank"
                 >
-                  2.1.1 Keyboard
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -758,9 +751,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
                   target="_blank"
                 >
-                  2.1.2 No Keyboard Trap
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -802,9 +794,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
                   target="_blank"
                 >
-                  2.2.1 Pause, Stop, Hide
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.1 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -846,9 +837,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-pause"
                   target="_blank"
                 >
-                  2.2.2 Timing Adjustable
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.2 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -890,9 +880,10 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate"
                   target="_blank"
                 >
-                  2.3.1 Three Flashes or Below Threshold
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -934,9 +925,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
                   target="_blank"
                 >
-                  2.4.1 Bypass Blocks
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -978,9 +968,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
                   target="_blank"
                 >
-                  2.4.2 Page Titled
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1022,9 +1011,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
                   target="_blank"
                 >
-                  2.4.3 Focus Order
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1066,9 +1054,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
                   target="_blank"
                 >
-                  2.4.4 Link Purpose (In Context)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1110,9 +1097,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id"
                   target="_blank"
                 >
-                  3.1.1 Language of Page
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1154,9 +1140,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
                   target="_blank"
                 >
-                  3.2.1 On Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1198,9 +1183,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
                   target="_blank"
                 >
-                  3.2.2 On Input
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1242,9 +1226,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-identified"
                   target="_blank"
                 >
-                  3.3.1 Error Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1286,9 +1269,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-cues"
                   target="_blank"
                 >
-                  3.3.2 Labels or Instructions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1330,9 +1312,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses"
                   target="_blank"
                 >
-                  4.1.1 Parsing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1374,9 +1355,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv"
                   target="_blank"
                 >
-                  4.1.2 Name, Role, Value
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1457,9 +1437,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
                   target="_blank"
                 >
-                  1.2.4 Captions (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1501,9 +1480,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
                   target="_blank"
                 >
-                  1.2.5 Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1545,9 +1525,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
                   target="_blank"
                 >
-                  1.4.3 Contrast (Minimum)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1589,9 +1568,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
                   target="_blank"
                 >
-                  1.4.4 Resize text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1633,9 +1611,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
                   target="_blank"
                 >
-                  1.4.5 Images of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1677,9 +1654,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
                   target="_blank"
                 >
-                  2.4.5 Multiple Ways
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1721,9 +1697,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
                   target="_blank"
                 >
-                  2.4.6 Headings and Labels
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1765,9 +1740,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
                   target="_blank"
                 >
-                  2.4.7 Focus Visible
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1809,9 +1783,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id"
                   target="_blank"
                 >
-                  3.1.2 Language of Parts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1853,9 +1826,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
                   target="_blank"
                 >
-                  3.2.3 Consistent Navigation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1897,9 +1869,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
                   target="_blank"
                 >
-                  3.2.4 Consistent Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1941,9 +1912,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
                   target="_blank"
                 >
-                  3.3.3 Error Suggestion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1985,9 +1955,10 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible"
                   target="_blank"
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2068,9 +2039,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-sign"
                   target="_blank"
                 >
-                  1.2.6 Sign Language (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.6 Sign Language (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2104,9 +2074,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad"
                   target="_blank"
                 >
-                  1.2.7 Extended Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.7 Extended Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2140,9 +2111,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc"
                   target="_blank"
                 >
-                  1.2.8 Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.8 Media Alternative (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2166,9 +2138,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only"
                   target="_blank"
                 >
-                  1.2.9 Audio-only (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.9 Audio-only (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2192,9 +2163,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7"
                   target="_blank"
                 >
-                  1.4.6 Contrast (Enhanced)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.6 Contrast (Enhanced)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2218,9 +2188,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio"
                   target="_blank"
                 >
-                  1.4.7 Low or No Background Audio
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.7 Low or No Background Audio<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2244,9 +2213,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation"
                   target="_blank"
                 >
-                  1.4.8 Visual Presentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.8 Visual Presentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2277,9 +2245,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images"
                   target="_blank"
                 >
-                  1.4.9 Images of Text (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.9 Images of Text (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2303,9 +2270,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs"
                   target="_blank"
                 >
-                  2.1.3 Keyboard (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.3 Keyboard (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2342,9 +2308,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions"
                   target="_blank"
                 >
-                  2.2.3 No Timing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.3 No Timing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2381,9 +2346,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-postponed"
                   target="_blank"
                 >
-                  2.2.4 Interruptions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.4 Interruptions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2407,9 +2371,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout"
                   target="_blank"
                 >
-                  2.2.5 Re-authenticating
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.5 Re-authenticating<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2445,9 +2408,8 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-three-times"
                   target="_blank"
                 >
-                  2.3.2 Three Flashes
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.2 Three Flashes<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2471,9 +2433,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location"
                   target="_blank"
                 >
-                  2.4.8 Location
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.8 Location<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2519,9 +2480,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link"
                   target="_blank"
                 >
-                  2.4.9 Link Purpose (Link Only)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.9 Link Purpose (Link Only)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2545,9 +2505,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings"
                   target="_blank"
                 >
-                  2.4.10 Section Headings
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.10 Section Headings<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2571,9 +2530,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-idioms"
                   target="_blank"
                 >
-                  3.1.3 Unusual Words
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.3 Unusual Words<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2608,9 +2566,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-located"
                   target="_blank"
                 >
-                  3.1.4 Abbreviations
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.4 Abbreviations<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2634,9 +2591,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-supplements"
                   target="_blank"
                 >
-                  3.1.5 Reading Level
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.5 Reading Level<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2660,9 +2616,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation"
                   target="_blank"
                 >
-                  3.1.6 Pronunciation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.6 Pronunciation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2686,9 +2641,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context"
                   target="_blank"
                 >
-                  3.2.5 Change on Request
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.5 Change on Request<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2712,9 +2666,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help"
                   target="_blank"
                 >
-                  3.3.5 Help
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.5 Help<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2738,9 +2691,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all"
                   target="_blank"
                 >
-                  3.3.6 Error Prevention (All)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.6 Error Prevention (All)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2827,9 +2779,8 @@
                   href="https://www.access-board.gov/ict/#302.1"
                   target="_blank"
                 >
-                  302.1 Without Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.1 Without Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2851,9 +2802,8 @@
                   href="https://www.access-board.gov/ict/#302.2"
                   target="_blank"
                 >
-                  302.2 With Limited Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.2 With Limited Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2875,9 +2825,8 @@
                   href="https://www.access-board.gov/ict/#302.3"
                   target="_blank"
                 >
-                  302.3 Without Perception of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.3 Without Perception of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2899,9 +2848,8 @@
                   href="https://www.access-board.gov/ict/#302.4"
                   target="_blank"
                 >
-                  302.4 Without Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.4 Without Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2923,9 +2871,8 @@
                   href="https://www.access-board.gov/ict/#302.5"
                   target="_blank"
                 >
-                  302.5 With Limited Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.5 With Limited Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2947,9 +2894,8 @@
                   href="https://www.access-board.gov/ict/#302.6"
                   target="_blank"
                 >
-                  302.6 Without Speech
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.6 Without Speech<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2971,9 +2917,8 @@
                   href="https://www.access-board.gov/ict/#302.7"
                   target="_blank"
                 >
-                  302.7 With Limited Manipulation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.7 With Limited Manipulation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2995,9 +2940,10 @@
                   href="https://www.access-board.gov/ict/#302.8"
                   target="_blank"
                 >
-                  302.8 With Limited Reach and Strength
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.8 With Limited Reach and Strength<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3019,9 +2965,9 @@
                   href="https://www.access-board.gov/ict/#302.9"
                   target="_blank"
                 >
-                  302.9 With Limited Language, Cognitive, and Learning Abilities
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.9 With Limited Language, Cognitive, and Learning
+                  Abilities<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3101,9 +3047,10 @@
                   href="https://www.access-board.gov/ict/#502.2.1"
                   target="_blank"
                 >
-                  502.2.1 User Control of Accessibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.2.1 User Control of Accessibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3125,9 +3072,10 @@
                   href="https://www.access-board.gov/ict/#502.2.2"
                   target="_blank"
                 >
-                  502.2.2 No Disruption of Accessibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.2.2 No Disruption of Accessibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3149,9 +3097,8 @@
                   href="https://www.access-board.gov/ict/#502.3.1"
                   target="_blank"
                 >
-                  502.3.1 Object Information
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.1 Object Information<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3173,9 +3120,10 @@
                   href="https://www.access-board.gov/ict/#502.3.2"
                   target="_blank"
                 >
-                  502.3.2 Modification of Object Information
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.2 Modification of Object Information<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3197,9 +3145,8 @@
                   href="https://www.access-board.gov/ict/#502.3.3"
                   target="_blank"
                 >
-                  502.3.3 Row, Column, and Headers
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.3 Row, Column, and Headers<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3221,9 +3168,8 @@
                   href="https://www.access-board.gov/ict/#502.3.4"
                   target="_blank"
                 >
-                  502.3.4 Values
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.4 Values<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3245,9 +3191,8 @@
                   href="https://www.access-board.gov/ict/#502.3.5"
                   target="_blank"
                 >
-                  502.3.5 Modification of Values
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.5 Modification of Values<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3269,9 +3214,8 @@
                   href="https://www.access-board.gov/ict/#502.3.6"
                   target="_blank"
                 >
-                  502.3.6 Label Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.6 Label Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3293,9 +3237,8 @@
                   href="https://www.access-board.gov/ict/#502.3.7"
                   target="_blank"
                 >
-                  502.3.7 Hierarchical Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.7 Hierarchical Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3317,9 +3260,8 @@
                   href="https://www.access-board.gov/ict/#502.3.8"
                   target="_blank"
                 >
-                  502.3.8 Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.8 Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3341,9 +3283,8 @@
                   href="https://www.access-board.gov/ict/#502.3.9"
                   target="_blank"
                 >
-                  502.3.9 Modification of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.9 Modification of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3365,9 +3306,8 @@
                   href="https://www.access-board.gov/ict/#502.3.10"
                   target="_blank"
                 >
-                  502.3.10 List of Actions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.10 List of Actions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3389,9 +3329,8 @@
                   href="https://www.access-board.gov/ict/#502.3.11"
                   target="_blank"
                 >
-                  502.3.11 Actions on Objects
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.11 Actions on Objects<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3413,9 +3352,8 @@
                   href="https://www.access-board.gov/ict/#502.3.12"
                   target="_blank"
                 >
-                  502.3.12 Focus Cursor
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.12 Focus Cursor<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3437,9 +3375,10 @@
                   href="https://www.access-board.gov/ict/#502.3.13"
                   target="_blank"
                 >
-                  502.3.13 Modification of Focus Cursor
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.13 Modification of Focus Cursor<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3461,9 +3400,8 @@
                   href="https://www.access-board.gov/ict/#502.3.14"
                   target="_blank"
                 >
-                  502.3.14 Event Notification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.3.14 Event Notification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3485,9 +3423,10 @@
                   href="https://www.access-board.gov/ict/#502.4"
                   target="_blank"
                 >
-                  502.4 Platform Accessibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  502.4 Platform Accessibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3509,9 +3448,8 @@
                   href="https://www.access-board.gov/ict/#503.2"
                   target="_blank"
                 >
-                  503.2 User Preferences
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  503.2 User Preferences<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3533,9 +3471,8 @@
                   href="https://www.access-board.gov/ict/#503.3"
                   target="_blank"
                 >
-                  503.3 Alternative User Interfaces
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  503.3 Alternative User Interfaces<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3557,9 +3494,8 @@
                   href="https://www.access-board.gov/ict/#503.4.1"
                   target="_blank"
                 >
-                  503.4.1 Caption Controls
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  503.4.1 Caption Controls<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3581,9 +3517,8 @@
                   href="https://www.access-board.gov/ict/#503.4.2"
                   target="_blank"
                 >
-                  503.4.2 Audio Description Controls
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  503.4.2 Audio Description Controls<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3605,9 +3540,8 @@
                   href="https://www.access-board.gov/ict/#504.2"
                   target="_blank"
                 >
-                  504.2 Content Creation or Editing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  504.2 Content Creation or Editing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3630,9 +3564,8 @@
                   target="_blank"
                 >
                   504.2.1 Preservation of Information Provided for Accessibility
-                  in Format Conversion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  in Format Conversion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3654,9 +3587,8 @@
                   href="https://www.access-board.gov/ict/#504.2.2"
                   target="_blank"
                 >
-                  504.2.2 PDF Export
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  504.2.2 PDF Export<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3717,9 +3649,10 @@
                   href="https://www.access-board.gov/ict/#602.2"
                   target="_blank"
                 >
-                  602.2 Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.2 Accessibility and Compatibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3741,9 +3674,10 @@
                   href="https://www.access-board.gov/ict/#602.3"
                   target="_blank"
                 >
-                  602.3 Electronic Support Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.3 Electronic Support Documentation<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3766,9 +3700,8 @@
                   target="_blank"
                 >
                   602.4 Alternate Formats for Non-Electronic Support
-                  Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  Documentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3790,9 +3723,9 @@
                   href="https://www.access-board.gov/ict/#603.2"
                   target="_blank"
                 >
-                  603.2 Information on Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.2 Information on Accessibility and Compatibility
+                  Features<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3814,9 +3747,10 @@
                   href="https://www.access-board.gov/ict/#603.3"
                   target="_blank"
                 >
-                  603.3 Accommodation of Communication Needs
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.3 Accommodation of Communication Needs<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3847,16 +3781,14 @@
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >OpenACR<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >GSA<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
             </div>

--- a/openacr/Plone-5.html
+++ b/openacr/Plone-5.html
@@ -201,9 +201,10 @@
               <tr>
                 <td>
                   <a href="https://www.w3.org/TR/WCAG20/" target="_blank"
-                    >Web Content Accessibility Guidelines 2.0
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    >Web Content Accessibility Guidelines 2.0<span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -219,9 +220,8 @@
                 <td>
                   <a href="https://www.access-board.gov/ict/" target="_blank"
                     >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -335,9 +335,8 @@
                   href="https://www.w3.org/TR/WCAG20/#text-equiv-all"
                   target="_blank"
                 >
-                  1.1.1 Non-text Content
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -390,9 +389,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt"
                   target="_blank"
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -434,9 +434,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-captions"
                   target="_blank"
                 >
-                  1.2.2 Captions (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -478,9 +477,9 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc"
                   target="_blank"
                 >
-                  1.2.3 Audio Description or Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -522,9 +521,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
                   target="_blank"
                 >
-                  1.3.1 Info and Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -566,9 +564,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
                   target="_blank"
                 >
-                  1.3.2 Meaningful Sequence
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -610,9 +607,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
                   target="_blank"
                 >
-                  1.3.3 Sensory Characteristics
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -654,9 +650,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
                   target="_blank"
                 >
-                  1.4.1 Use of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -698,9 +693,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
                   target="_blank"
                 >
-                  1.4.2 Audio Control
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -742,9 +736,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
                   target="_blank"
                 >
-                  2.1.1 Keyboard
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -786,9 +779,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
                   target="_blank"
                 >
-                  2.1.2 No Keyboard Trap
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -830,9 +822,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
                   target="_blank"
                 >
-                  2.2.1 Pause, Stop, Hide
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.1 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -874,9 +865,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-pause"
                   target="_blank"
                 >
-                  2.2.2 Timing Adjustable
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.2 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -918,9 +908,10 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate"
                   target="_blank"
                 >
-                  2.3.1 Three Flashes or Below Threshold
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -962,9 +953,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
                   target="_blank"
                 >
-                  2.4.1 Bypass Blocks
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1006,9 +996,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
                   target="_blank"
                 >
-                  2.4.2 Page Titled
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1050,9 +1039,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
                   target="_blank"
                 >
-                  2.4.3 Focus Order
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1094,9 +1082,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
                   target="_blank"
                 >
-                  2.4.4 Link Purpose (In Context)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1138,9 +1125,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id"
                   target="_blank"
                 >
-                  3.1.1 Language of Page
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1182,9 +1168,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
                   target="_blank"
                 >
-                  3.2.1 On Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1226,9 +1211,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
                   target="_blank"
                 >
-                  3.2.2 On Input
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1270,9 +1254,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-identified"
                   target="_blank"
                 >
-                  3.3.1 Error Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1314,9 +1297,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-cues"
                   target="_blank"
                 >
-                  3.3.2 Labels or Instructions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1358,9 +1340,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses"
                   target="_blank"
                 >
-                  4.1.1 Parsing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1402,9 +1383,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv"
                   target="_blank"
                 >
-                  4.1.2 Name, Role, Value
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1485,9 +1465,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
                   target="_blank"
                 >
-                  1.2.4 Captions (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1523,9 +1502,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
                   target="_blank"
                 >
-                  1.2.5 Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1567,9 +1547,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
                   target="_blank"
                 >
-                  1.4.3 Contrast (Minimum)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1611,9 +1590,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
                   target="_blank"
                 >
-                  1.4.4 Resize text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1649,9 +1627,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
                   target="_blank"
                 >
-                  1.4.5 Images of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1693,9 +1670,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
                   target="_blank"
                 >
-                  2.4.5 Multiple Ways
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1737,9 +1713,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
                   target="_blank"
                 >
-                  2.4.6 Headings and Labels
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1781,9 +1756,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
                   target="_blank"
                 >
-                  2.4.7 Focus Visible
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1825,9 +1799,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id"
                   target="_blank"
                 >
-                  3.1.2 Language of Parts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1869,9 +1842,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
                   target="_blank"
                 >
-                  3.2.3 Consistent Navigation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1907,9 +1879,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
                   target="_blank"
                 >
-                  3.2.4 Consistent Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1951,9 +1922,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
                   target="_blank"
                 >
-                  3.3.3 Error Suggestion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1995,9 +1965,10 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible"
                   target="_blank"
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2078,9 +2049,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-sign"
                   target="_blank"
                 >
-                  1.2.6 Sign Language (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.6 Sign Language (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2104,9 +2074,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-extended-ad"
                   target="_blank"
                 >
-                  1.2.7 Extended Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.7 Extended Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2130,9 +2101,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-text-doc"
                   target="_blank"
                 >
-                  1.2.8 Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.8 Media Alternative (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2156,9 +2128,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-live-audio-only"
                   target="_blank"
                 >
-                  1.2.9 Audio-only (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.9 Audio-only (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2182,9 +2153,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast7"
                   target="_blank"
                 >
-                  1.4.6 Contrast (Enhanced)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.6 Contrast (Enhanced)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2208,9 +2178,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-noaudio"
                   target="_blank"
                 >
-                  1.4.7 Low or No Background Audio
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.7 Low or No Background Audio<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2234,9 +2203,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-visual-presentation"
                   target="_blank"
                 >
-                  1.4.8 Visual Presentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.8 Visual Presentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2260,9 +2228,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-images"
                   target="_blank"
                 >
-                  1.4.9 Images of Text (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.9 Images of Text (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2286,9 +2253,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-all-funcs"
                   target="_blank"
                 >
-                  2.1.3 Keyboard (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.3 Keyboard (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2312,9 +2278,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-no-exceptions"
                   target="_blank"
                 >
-                  2.2.3 No Timing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.3 No Timing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2338,9 +2303,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-postponed"
                   target="_blank"
                 >
-                  2.2.4 Interruptions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.4 Interruptions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2364,9 +2328,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-server-timeout"
                   target="_blank"
                 >
-                  2.2.5 Re-authenticating
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.5 Re-authenticating<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2390,9 +2353,8 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-three-times"
                   target="_blank"
                 >
-                  2.3.2 Three Flashes
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.2 Three Flashes<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2416,9 +2378,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-location"
                   target="_blank"
                 >
-                  2.4.8 Location
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.8 Location<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2442,9 +2403,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-link"
                   target="_blank"
                 >
-                  2.4.9 Link Purpose (Link Only)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.9 Link Purpose (Link Only)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2468,9 +2428,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-headings"
                   target="_blank"
                 >
-                  2.4.10 Section Headings
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.10 Section Headings<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2494,9 +2453,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-idioms"
                   target="_blank"
                 >
-                  3.1.3 Unusual Words
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.3 Unusual Words<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2520,9 +2478,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-located"
                   target="_blank"
                 >
-                  3.1.4 Abbreviations
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.4 Abbreviations<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2546,9 +2503,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-supplements"
                   target="_blank"
                 >
-                  3.1.5 Reading Level
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.5 Reading Level<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2572,9 +2528,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-pronunciation"
                   target="_blank"
                 >
-                  3.1.6 Pronunciation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.6 Pronunciation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2598,9 +2553,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-no-extreme-changes-context"
                   target="_blank"
                 >
-                  3.2.5 Change on Request
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.5 Change on Request<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2624,9 +2578,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-context-help"
                   target="_blank"
                 >
-                  3.3.5 Help
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.5 Help<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2650,9 +2603,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible-all"
                   target="_blank"
                 >
-                  3.3.6 Error Prevention (All)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.6 Error Prevention (All)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2728,9 +2680,8 @@
                   href="https://www.access-board.gov/ict/#302.1"
                   target="_blank"
                 >
-                  302.1 Without Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.1 Without Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2752,9 +2703,8 @@
                   href="https://www.access-board.gov/ict/#302.2"
                   target="_blank"
                 >
-                  302.2 With Limited Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.2 With Limited Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2776,9 +2726,8 @@
                   href="https://www.access-board.gov/ict/#302.3"
                   target="_blank"
                 >
-                  302.3 Without Perception of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.3 Without Perception of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2800,9 +2749,8 @@
                   href="https://www.access-board.gov/ict/#302.4"
                   target="_blank"
                 >
-                  302.4 Without Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.4 Without Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2824,9 +2772,8 @@
                   href="https://www.access-board.gov/ict/#302.5"
                   target="_blank"
                 >
-                  302.5 With Limited Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.5 With Limited Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2848,9 +2795,8 @@
                   href="https://www.access-board.gov/ict/#302.6"
                   target="_blank"
                 >
-                  302.6 Without Speech
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.6 Without Speech<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2872,9 +2818,8 @@
                   href="https://www.access-board.gov/ict/#302.7"
                   target="_blank"
                 >
-                  302.7 With Limited Manipulation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.7 With Limited Manipulation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2896,9 +2841,10 @@
                   href="https://www.access-board.gov/ict/#302.8"
                   target="_blank"
                 >
-                  302.8 With Limited Reach and Strength
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.8 With Limited Reach and Strength<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2920,9 +2866,9 @@
                   href="https://www.access-board.gov/ict/#302.9"
                   target="_blank"
                 >
-                  302.9 With Limited Language, Cognitive, and Learning Abilities
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.9 With Limited Language, Cognitive, and Learning
+                  Abilities<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3021,16 +2967,14 @@
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >OpenACR<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >GSA<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
             </div>

--- a/openacr/drupal-9-simple.html
+++ b/openacr/drupal-9-simple.html
@@ -325,9 +325,10 @@
               <tr>
                 <td>
                   <a href="https://www.w3.org/TR/WCAG21/" target="_blank"
-                    >Web Content Accessibility Guidelines 2.1
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    >Web Content Accessibility Guidelines 2.1<span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -343,9 +344,8 @@
                 <td>
                   <a href="https://www.access-board.gov/ict/" target="_blank"
                     >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -474,9 +474,8 @@
                   href="https://www.w3.org/TR/WCAG21/#non-text-content"
                   target="_blank"
                 >
-                  1.1.1 Non-text Content
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -547,9 +546,10 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded"
                   target="_blank"
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -616,9 +616,8 @@
                   href="https://www.w3.org/TR/WCAG21/#captions-prerecorded"
                   target="_blank"
                 >
-                  1.2.2 Captions (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -681,9 +680,9 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded"
                   target="_blank"
                 >
-                  1.2.3 Audio Description or Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -754,9 +753,8 @@
                   href="https://www.w3.org/TR/WCAG21/#info-and-relationships"
                   target="_blank"
                 >
-                  1.3.1 Info and Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -832,9 +830,8 @@
                   href="https://www.w3.org/TR/WCAG21/#meaningful-sequence"
                   target="_blank"
                 >
-                  1.3.2 Meaningful Sequence
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -896,9 +893,8 @@
                   href="https://www.w3.org/TR/WCAG21/#sensory-characteristics"
                   target="_blank"
                 >
-                  1.3.3 Sensory Characteristics
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -959,9 +955,8 @@
                   href="https://www.w3.org/TR/WCAG21/#use-of-color"
                   target="_blank"
                 >
-                  1.4.1 Use of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1023,9 +1018,8 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-control"
                   target="_blank"
                 >
-                  1.4.2 Audio Control
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1067,9 +1061,8 @@
                   href="https://www.w3.org/TR/WCAG21/#keyboard"
                   target="_blank"
                 >
-                  2.1.1 Keyboard
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1135,9 +1128,8 @@
                   href="https://www.w3.org/TR/WCAG21/#no-keyboard-trap"
                   target="_blank"
                 >
-                  2.1.2 No Keyboard Trap
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1198,9 +1190,8 @@
                   href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
                   target="_blank"
                 >
-                  2.1.4 Character Key Shortcuts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.4 Character Key Shortcuts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1217,9 +1208,8 @@
                   href="https://www.w3.org/TR/WCAG21/#time-limits-required-behaviors"
                   target="_blank"
                 >
-                  2.2.1 Pause, Stop, Hide
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.1 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1274,9 +1264,8 @@
                   href="https://www.w3.org/TR/WCAG21/#timing-adjustable"
                   target="_blank"
                 >
-                  2.2.2 Timing Adjustable
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.2 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1318,9 +1307,10 @@
                   href="https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold"
                   target="_blank"
                 >
-                  2.3.1 Three Flashes or Below Threshold
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1375,9 +1365,8 @@
                   href="https://www.w3.org/TR/WCAG21/#bypass-blocks"
                   target="_blank"
                 >
-                  2.4.1 Bypass Blocks
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1438,9 +1427,8 @@
                   href="https://www.w3.org/TR/WCAG21/#page-titled"
                   target="_blank"
                 >
-                  2.4.2 Page Titled
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1501,9 +1489,8 @@
                   href="https://www.w3.org/TR/WCAG21/#focus-order"
                   target="_blank"
                 >
-                  2.4.3 Focus Order
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1573,9 +1560,8 @@
                   href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context"
                   target="_blank"
                 >
-                  2.4.4 Link Purpose (In Context)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1638,9 +1624,8 @@
                   href="https://www.w3.org/TR/WCAG21/#pointer-gestures"
                   target="_blank"
                 >
-                  2.5.1 Pointer Gestures
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.1 Pointer Gestures<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1657,9 +1642,8 @@
                   href="https://www.w3.org/TR/WCAG21/#pointer-cancellation"
                   target="_blank"
                 >
-                  2.5.2 Pointer Cancellation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.2 Pointer Cancellation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1676,9 +1660,8 @@
                   href="https://www.w3.org/TR/WCAG21/#label-in-name"
                   target="_blank"
                 >
-                  2.5.3 Label in Name
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.3 Label in Name<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1695,9 +1678,8 @@
                   href="https://www.w3.org/TR/WCAG21/#motion-actuation"
                   target="_blank"
                 >
-                  2.5.4 Motion Actuation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.4 Motion Actuation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1714,9 +1696,8 @@
                   href="https://www.w3.org/TR/WCAG21/#language-of-page"
                   target="_blank"
                 >
-                  3.1.1 Language of Page
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1777,9 +1758,8 @@
                   href="https://www.w3.org/TR/WCAG21/#on-focus"
                   target="_blank"
                 >
-                  3.2.1 On Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1849,9 +1829,8 @@
                   href="https://www.w3.org/TR/WCAG21/#on-input"
                   target="_blank"
                 >
-                  3.2.2 On Input
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1921,9 +1900,8 @@
                   href="https://www.w3.org/TR/WCAG21/#error-identification"
                   target="_blank"
                 >
-                  3.3.1 Error Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1984,9 +1962,8 @@
                   href="https://www.w3.org/TR/WCAG21/#labels-or-instructions"
                   target="_blank"
                 >
-                  3.3.2 Labels or Instructions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2042,9 +2019,8 @@
             <tr id="4.1.1">
               <td>
                 <a href="https://www.w3.org/TR/WCAG21/#parsing" target="_blank">
-                  4.1.1 Parsing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2115,9 +2091,8 @@
                   href="https://www.w3.org/TR/WCAG21/#name-role-value"
                   target="_blank"
                 >
-                  4.1.2 Name, Role, Value
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2221,9 +2196,8 @@
                   href="https://www.w3.org/TR/WCAG21/#captions-live"
                   target="_blank"
                 >
-                  1.2.4 Captions (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2259,9 +2233,10 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-description-prerecorded"
                   target="_blank"
                 >
-                  1.2.5 Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2332,9 +2307,8 @@
                   href="https://www.w3.org/TR/WCAG21/#orientation"
                   target="_blank"
                 >
-                  1.3.4 Orientation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.4 Orientation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2351,9 +2325,8 @@
                   href="https://www.w3.org/TR/WCAG21/#identify-input-purpose"
                   target="_blank"
                 >
-                  1.3.5 Identify Input Purpose
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.5 Identify Input Purpose<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2370,9 +2343,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-contrast"
                   target="_blank"
                 >
-                  1.4.3 Contrast (Minimum)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2439,9 +2411,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-scale"
                   target="_blank"
                 >
-                  1.4.4 Resize text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2508,9 +2479,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-text-presentation"
                   target="_blank"
                 >
-                  1.4.5 Images of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2560,9 +2530,8 @@
             <tr id="1.4.10">
               <td>
                 <a href="https://www.w3.org/TR/WCAG21/#reflow" target="_blank">
-                  1.4.10 Reflow
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.10 Reflow<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2579,9 +2548,8 @@
                   href="https://www.w3.org/TR/WCAG21/#non-text-contrast"
                   target="_blank"
                 >
-                  1.4.11 Non-text Contrast
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.11 Non-text Contrast<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2598,9 +2566,8 @@
                   href="https://www.w3.org/TR/WCAG21/#text-spacing"
                   target="_blank"
                 >
-                  1.4.12 Text Spacing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.12 Text Spacing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2617,9 +2584,8 @@
                   href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
                   target="_blank"
                 >
-                  1.4.13 Content on Hover or Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.13 Content on Hover or Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2636,9 +2602,8 @@
                   href="https://www.w3.org/TR/WCAG21/#multiple-ways"
                   target="_blank"
                 >
-                  2.4.5 Multiple Ways
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2702,9 +2667,8 @@
                   href="https://www.w3.org/TR/WCAG21/#headings-and-labels"
                   target="_blank"
                 >
-                  2.4.6 Headings and Labels
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2768,9 +2732,8 @@
                   href="https://www.w3.org/TR/WCAG21/#focus-visible"
                   target="_blank"
                 >
-                  2.4.7 Focus Visible
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2833,9 +2796,8 @@
                   href="https://www.w3.org/TR/WCAG21/#language-of-parts"
                   target="_blank"
                 >
-                  3.1.2 Language of Parts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2900,9 +2862,8 @@
                   href="https://www.w3.org/TR/WCAG21/#consistent-navigation"
                   target="_blank"
                 >
-                  3.2.3 Consistent Navigation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2966,9 +2927,8 @@
                   href="https://www.w3.org/TR/WCAG21/#consistent-identification"
                   target="_blank"
                 >
-                  3.2.4 Consistent Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3032,9 +2992,8 @@
                   href="https://www.w3.org/TR/WCAG21/#error-suggestion"
                   target="_blank"
                 >
-                  3.3.3 Error Suggestion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3095,9 +3054,10 @@
                   href="https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data"
                   target="_blank"
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3161,9 +3121,8 @@
                   href="https://www.w3.org/TR/WCAG21/#status-messages"
                   target="_blank"
                 >
-                  4.1.3 Status Messages
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.3 Status Messages<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3229,9 +3188,8 @@
                   href="https://www.w3.org/TR/WCAG21/#sign-language-prerecorded"
                   target="_blank"
                 >
-                  1.2.6 Sign Language (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.6 Sign Language (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3255,9 +3213,10 @@
                   href="https://www.w3.org/TR/WCAG21/#extended-audio-description-prerecorded"
                   target="_blank"
                 >
-                  1.2.7 Extended Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.7 Extended Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3281,9 +3240,10 @@
                   href="https://www.w3.org/TR/WCAG21/#media-alternative-prerecorded"
                   target="_blank"
                 >
-                  1.2.8 Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.8 Media Alternative (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3307,9 +3267,8 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-only-live"
                   target="_blank"
                 >
-                  1.2.9 Audio-only (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.9 Audio-only (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3333,9 +3292,8 @@
                   href="https://www.w3.org/TR/WCAG21/#identify-purpose"
                   target="_blank"
                 >
-                  1.3.6 Identify Purpose
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.6 Identify Purpose<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3352,9 +3310,8 @@
                   href="https://www.w3.org/TR/WCAG21/#contrast-enhanced"
                   target="_blank"
                 >
-                  1.4.6 Contrast (Enhanced)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.6 Contrast (Enhanced)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3388,9 +3345,8 @@
                   href="https://www.w3.org/TR/WCAG21/#low-or-no-background-audio"
                   target="_blank"
                 >
-                  1.4.7 Low or No Background Audio
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.7 Low or No Background Audio<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3414,9 +3370,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-presentation"
                   target="_blank"
                 >
-                  1.4.8 Visual Presentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.8 Visual Presentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3451,9 +3406,8 @@
                   href="https://www.w3.org/TR/WCAG21/#images-of-text-no-exception"
                   target="_blank"
                 >
-                  1.4.9 Images of Text (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.9 Images of Text (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3484,9 +3438,8 @@
                   href="https://www.w3.org/TR/WCAG21/#keyboard-no-exception"
                   target="_blank"
                 >
-                  2.1.3 Keyboard (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.3 Keyboard (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3519,9 +3472,8 @@
                   href="https://www.w3.org/TR/WCAG21/#no-timing"
                   target="_blank"
                 >
-                  2.2.3 No Timing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.3 No Timing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3555,9 +3507,8 @@
                   href="https://www.w3.org/TR/WCAG21/#interruptions"
                   target="_blank"
                 >
-                  2.2.4 Interruptions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.4 Interruptions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3581,9 +3532,8 @@
                   href="https://www.w3.org/TR/WCAG21/#re-authenticating"
                   target="_blank"
                 >
-                  2.2.5 Re-authenticating
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.5 Re-authenticating<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3607,9 +3557,8 @@
                   href="https://www.w3.org/TR/WCAG21/#timeouts"
                   target="_blank"
                 >
-                  2.2.6 Timeouts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.6 Timeouts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3626,9 +3575,8 @@
                   href="https://www.w3.org/TR/WCAG21/#three-flashes"
                   target="_blank"
                 >
-                  2.3.2 Three Flashes
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.2 Three Flashes<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3659,9 +3607,8 @@
                   href="https://www.w3.org/TR/WCAG21/#animation-from-interactions"
                   target="_blank"
                 >
-                  2.3.3 Animation from Interactions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.3 Animation from Interactions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3678,9 +3625,8 @@
                   href="https://www.w3.org/TR/WCAG21/#location"
                   target="_blank"
                 >
-                  2.4.8 Location
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.8 Location<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3714,9 +3660,8 @@
                   href="https://www.w3.org/TR/WCAG21/#link-purpose-link-only"
                   target="_blank"
                 >
-                  2.4.9 Link Purpose (Link Only)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.9 Link Purpose (Link Only)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3750,9 +3695,8 @@
                   href="https://www.w3.org/TR/WCAG21/#section-headings"
                   target="_blank"
                 >
-                  2.4.10 Section Headings
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.10 Section Headings<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3786,9 +3730,8 @@
                   href="https://www.w3.org/TR/WCAG21/#target-size"
                   target="_blank"
                 >
-                  2.5.5 Target Size
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.5 Target Size<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3805,9 +3748,8 @@
                   href="https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms"
                   target="_blank"
                 >
-                  2.5.6 Concurrent Input Mechanisms
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.6 Concurrent Input Mechanisms<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3824,9 +3766,8 @@
                   href="https://www.w3.org/TR/WCAG21/#unusual-words"
                   target="_blank"
                 >
-                  3.1.3 Unusual Words
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.3 Unusual Words<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3850,9 +3791,8 @@
                   href="https://www.w3.org/TR/WCAG21/#abbreviations"
                   target="_blank"
                 >
-                  3.1.4 Abbreviations
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.4 Abbreviations<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3876,9 +3816,8 @@
                   href="https://www.w3.org/TR/WCAG21/#reading-level"
                   target="_blank"
                 >
-                  3.1.5 Reading Level
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.5 Reading Level<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3902,9 +3841,8 @@
                   href="https://www.w3.org/TR/WCAG21/#pronunciation"
                   target="_blank"
                 >
-                  3.1.6 Pronunciation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.6 Pronunciation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3928,9 +3866,8 @@
                   href="https://www.w3.org/TR/WCAG21/#change-on-request"
                   target="_blank"
                 >
-                  3.2.5 Change on Request
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.5 Change on Request<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3951,9 +3888,8 @@
             <tr id="3.3.5">
               <td>
                 <a href="https://www.w3.org/TR/WCAG21/#help" target="_blank">
-                  3.3.5 Help
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.5 Help<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3977,9 +3913,8 @@
                   href="https://www.w3.org/TR/WCAG21/#error-prevention-all"
                   target="_blank"
                 >
-                  3.3.6 Error Prevention (All)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.6 Error Prevention (All)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4063,9 +3998,8 @@
                   href="https://www.access-board.gov/ict/#302.1"
                   target="_blank"
                 >
-                  302.1 Without Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.1 Without Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4092,9 +4026,8 @@
                   href="https://www.access-board.gov/ict/#302.2"
                   target="_blank"
                 >
-                  302.2 With Limited Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.2 With Limited Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4121,9 +4054,8 @@
                   href="https://www.access-board.gov/ict/#302.3"
                   target="_blank"
                 >
-                  302.3 Without Perception of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.3 Without Perception of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4150,9 +4082,8 @@
                   href="https://www.access-board.gov/ict/#302.4"
                   target="_blank"
                 >
-                  302.4 Without Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.4 Without Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4174,9 +4105,8 @@
                   href="https://www.access-board.gov/ict/#302.5"
                   target="_blank"
                 >
-                  302.5 With Limited Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.5 With Limited Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4198,9 +4128,8 @@
                   href="https://www.access-board.gov/ict/#302.6"
                   target="_blank"
                 >
-                  302.6 Without Speech
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.6 Without Speech<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4222,9 +4151,8 @@
                   href="https://www.access-board.gov/ict/#302.7"
                   target="_blank"
                 >
-                  302.7 With Limited Manipulation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.7 With Limited Manipulation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4254,9 +4182,10 @@
                   href="https://www.access-board.gov/ict/#302.8"
                   target="_blank"
                 >
-                  302.8 With Limited Reach and Strength
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.8 With Limited Reach and Strength<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4286,9 +4215,9 @@
                   href="https://www.access-board.gov/ict/#302.9"
                   target="_blank"
                 >
-                  302.9 With Limited Language, Cognitive, and Learning Abilities
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.9 With Limited Language, Cognitive, and Learning
+                  Abilities<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4405,9 +4334,10 @@
                   href="https://www.access-board.gov/ict/#602.2"
                   target="_blank"
                 >
-                  602.2 Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.2 Accessibility and Compatibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4430,9 +4360,8 @@
                   target="_blank"
                 >
                   602.4 Alternate Formats for Non-Electronic Support
-                  Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  Documentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4454,9 +4383,9 @@
                   href="https://www.access-board.gov/ict/#603.2"
                   target="_blank"
                 >
-                  603.2 Information on Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.2 Information on Accessibility and Compatibility
+                  Features<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4478,9 +4407,10 @@
                   href="https://www.access-board.gov/ict/#603.3"
                   target="_blank"
                 >
-                  603.3 Accommodation of Communication Needs
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.3 Accommodation of Communication Needs<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4502,9 +4432,10 @@
                   href="https://www.access-board.gov/ict/#602.3"
                   target="_blank"
                 >
-                  602.3 Electronic Support Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.3 Electronic Support Documentation<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4607,16 +4538,14 @@
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >OpenACR<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >GSA<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
             </div>

--- a/openacr/drupal-9.html
+++ b/openacr/drupal-9.html
@@ -228,9 +228,10 @@
               <tr>
                 <td>
                   <a href="https://www.w3.org/TR/WCAG21/" target="_blank"
-                    >Web Content Accessibility Guidelines 2.1
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    >Web Content Accessibility Guidelines 2.1<span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -246,9 +247,8 @@
                 <td>
                   <a href="https://www.access-board.gov/ict/" target="_blank"
                     >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -377,9 +377,8 @@
                   href="https://www.w3.org/TR/WCAG21/#non-text-content"
                   target="_blank"
                 >
-                  1.1.1 Non-text Content
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -450,9 +449,10 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-only-and-video-only-prerecorded"
                   target="_blank"
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -519,9 +519,8 @@
                   href="https://www.w3.org/TR/WCAG21/#captions-prerecorded"
                   target="_blank"
                 >
-                  1.2.2 Captions (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -584,9 +583,9 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-description-or-media-alternative-prerecorded"
                   target="_blank"
                 >
-                  1.2.3 Audio Description or Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -657,9 +656,8 @@
                   href="https://www.w3.org/TR/WCAG21/#info-and-relationships"
                   target="_blank"
                 >
-                  1.3.1 Info and Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -735,9 +733,8 @@
                   href="https://www.w3.org/TR/WCAG21/#meaningful-sequence"
                   target="_blank"
                 >
-                  1.3.2 Meaningful Sequence
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -799,9 +796,8 @@
                   href="https://www.w3.org/TR/WCAG21/#sensory-characteristics"
                   target="_blank"
                 >
-                  1.3.3 Sensory Characteristics
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -862,9 +858,8 @@
                   href="https://www.w3.org/TR/WCAG21/#use-of-color"
                   target="_blank"
                 >
-                  1.4.1 Use of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -926,9 +921,8 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-control"
                   target="_blank"
                 >
-                  1.4.2 Audio Control
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -970,9 +964,8 @@
                   href="https://www.w3.org/TR/WCAG21/#keyboard"
                   target="_blank"
                 >
-                  2.1.1 Keyboard
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1038,9 +1031,8 @@
                   href="https://www.w3.org/TR/WCAG21/#no-keyboard-trap"
                   target="_blank"
                 >
-                  2.1.2 No Keyboard Trap
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1101,9 +1093,8 @@
                   href="https://www.w3.org/TR/WCAG21/#character-key-shortcuts"
                   target="_blank"
                 >
-                  2.1.4 Character Key Shortcuts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.4 Character Key Shortcuts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1120,9 +1111,8 @@
                   href="https://www.w3.org/TR/WCAG21/#time-limits-required-behaviors"
                   target="_blank"
                 >
-                  2.2.1 Pause, Stop, Hide
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.1 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1177,9 +1167,8 @@
                   href="https://www.w3.org/TR/WCAG21/#timing-adjustable"
                   target="_blank"
                 >
-                  2.2.2 Timing Adjustable
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.2 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1221,9 +1210,10 @@
                   href="https://www.w3.org/TR/WCAG21/#three-flashes-or-below-threshold"
                   target="_blank"
                 >
-                  2.3.1 Three Flashes or Below Threshold
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1278,9 +1268,8 @@
                   href="https://www.w3.org/TR/WCAG21/#bypass-blocks"
                   target="_blank"
                 >
-                  2.4.1 Bypass Blocks
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1341,9 +1330,8 @@
                   href="https://www.w3.org/TR/WCAG21/#page-titled"
                   target="_blank"
                 >
-                  2.4.2 Page Titled
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1404,9 +1392,8 @@
                   href="https://www.w3.org/TR/WCAG21/#focus-order"
                   target="_blank"
                 >
-                  2.4.3 Focus Order
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1476,9 +1463,8 @@
                   href="https://www.w3.org/TR/WCAG21/#link-purpose-in-context"
                   target="_blank"
                 >
-                  2.4.4 Link Purpose (In Context)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1541,9 +1527,8 @@
                   href="https://www.w3.org/TR/WCAG21/#pointer-gestures"
                   target="_blank"
                 >
-                  2.5.1 Pointer Gestures
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.1 Pointer Gestures<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1560,9 +1545,8 @@
                   href="https://www.w3.org/TR/WCAG21/#pointer-cancellation"
                   target="_blank"
                 >
-                  2.5.2 Pointer Cancellation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.2 Pointer Cancellation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1579,9 +1563,8 @@
                   href="https://www.w3.org/TR/WCAG21/#label-in-name"
                   target="_blank"
                 >
-                  2.5.3 Label in Name
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.3 Label in Name<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1598,9 +1581,8 @@
                   href="https://www.w3.org/TR/WCAG21/#motion-actuation"
                   target="_blank"
                 >
-                  2.5.4 Motion Actuation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.4 Motion Actuation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1617,9 +1599,8 @@
                   href="https://www.w3.org/TR/WCAG21/#language-of-page"
                   target="_blank"
                 >
-                  3.1.1 Language of Page
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1680,9 +1661,8 @@
                   href="https://www.w3.org/TR/WCAG21/#on-focus"
                   target="_blank"
                 >
-                  3.2.1 On Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1752,9 +1732,8 @@
                   href="https://www.w3.org/TR/WCAG21/#on-input"
                   target="_blank"
                 >
-                  3.2.2 On Input
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1824,9 +1803,8 @@
                   href="https://www.w3.org/TR/WCAG21/#error-identification"
                   target="_blank"
                 >
-                  3.3.1 Error Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1887,9 +1865,8 @@
                   href="https://www.w3.org/TR/WCAG21/#labels-or-instructions"
                   target="_blank"
                 >
-                  3.3.2 Labels or Instructions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1945,9 +1922,8 @@
             <tr id="4.1.1">
               <td>
                 <a href="https://www.w3.org/TR/WCAG21/#parsing" target="_blank">
-                  4.1.1 Parsing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2018,9 +1994,8 @@
                   href="https://www.w3.org/TR/WCAG21/#name-role-value"
                   target="_blank"
                 >
-                  4.1.2 Name, Role, Value
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2124,9 +2099,8 @@
                   href="https://www.w3.org/TR/WCAG21/#captions-live"
                   target="_blank"
                 >
-                  1.2.4 Captions (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2162,9 +2136,10 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-description-prerecorded"
                   target="_blank"
                 >
-                  1.2.5 Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2235,9 +2210,8 @@
                   href="https://www.w3.org/TR/WCAG21/#orientation"
                   target="_blank"
                 >
-                  1.3.4 Orientation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.4 Orientation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2254,9 +2228,8 @@
                   href="https://www.w3.org/TR/WCAG21/#identify-input-purpose"
                   target="_blank"
                 >
-                  1.3.5 Identify Input Purpose
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.5 Identify Input Purpose<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2273,9 +2246,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-contrast"
                   target="_blank"
                 >
-                  1.4.3 Contrast (Minimum)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2342,9 +2314,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-scale"
                   target="_blank"
                 >
-                  1.4.4 Resize text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2411,9 +2382,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-audio-contrast-text-presentation"
                   target="_blank"
                 >
-                  1.4.5 Images of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2463,9 +2433,8 @@
             <tr id="1.4.10">
               <td>
                 <a href="https://www.w3.org/TR/WCAG21/#reflow" target="_blank">
-                  1.4.10 Reflow
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.10 Reflow<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2482,9 +2451,8 @@
                   href="https://www.w3.org/TR/WCAG21/#non-text-contrast"
                   target="_blank"
                 >
-                  1.4.11 Non-text Contrast
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.11 Non-text Contrast<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2501,9 +2469,8 @@
                   href="https://www.w3.org/TR/WCAG21/#text-spacing"
                   target="_blank"
                 >
-                  1.4.12 Text Spacing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.12 Text Spacing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2520,9 +2487,8 @@
                   href="https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus"
                   target="_blank"
                 >
-                  1.4.13 Content on Hover or Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.13 Content on Hover or Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2539,9 +2505,8 @@
                   href="https://www.w3.org/TR/WCAG21/#multiple-ways"
                   target="_blank"
                 >
-                  2.4.5 Multiple Ways
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2605,9 +2570,8 @@
                   href="https://www.w3.org/TR/WCAG21/#headings-and-labels"
                   target="_blank"
                 >
-                  2.4.6 Headings and Labels
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2671,9 +2635,8 @@
                   href="https://www.w3.org/TR/WCAG21/#focus-visible"
                   target="_blank"
                 >
-                  2.4.7 Focus Visible
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2736,9 +2699,8 @@
                   href="https://www.w3.org/TR/WCAG21/#language-of-parts"
                   target="_blank"
                 >
-                  3.1.2 Language of Parts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2803,9 +2765,8 @@
                   href="https://www.w3.org/TR/WCAG21/#consistent-navigation"
                   target="_blank"
                 >
-                  3.2.3 Consistent Navigation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2869,9 +2830,8 @@
                   href="https://www.w3.org/TR/WCAG21/#consistent-identification"
                   target="_blank"
                 >
-                  3.2.4 Consistent Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2935,9 +2895,8 @@
                   href="https://www.w3.org/TR/WCAG21/#error-suggestion"
                   target="_blank"
                 >
-                  3.3.3 Error Suggestion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2998,9 +2957,10 @@
                   href="https://www.w3.org/TR/WCAG21/#error-prevention-legal-financial-data"
                   target="_blank"
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3064,9 +3024,8 @@
                   href="https://www.w3.org/TR/WCAG21/#status-messages"
                   target="_blank"
                 >
-                  4.1.3 Status Messages
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.3 Status Messages<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3132,9 +3091,8 @@
                   href="https://www.w3.org/TR/WCAG21/#sign-language-prerecorded"
                   target="_blank"
                 >
-                  1.2.6 Sign Language (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.6 Sign Language (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3158,9 +3116,10 @@
                   href="https://www.w3.org/TR/WCAG21/#extended-audio-description-prerecorded"
                   target="_blank"
                 >
-                  1.2.7 Extended Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.7 Extended Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3184,9 +3143,10 @@
                   href="https://www.w3.org/TR/WCAG21/#media-alternative-prerecorded"
                   target="_blank"
                 >
-                  1.2.8 Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.8 Media Alternative (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3210,9 +3170,8 @@
                   href="https://www.w3.org/TR/WCAG21/#audio-only-live"
                   target="_blank"
                 >
-                  1.2.9 Audio-only (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.9 Audio-only (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3236,9 +3195,8 @@
                   href="https://www.w3.org/TR/WCAG21/#identify-purpose"
                   target="_blank"
                 >
-                  1.3.6 Identify Purpose
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.6 Identify Purpose<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3255,9 +3213,8 @@
                   href="https://www.w3.org/TR/WCAG21/#contrast-enhanced"
                   target="_blank"
                 >
-                  1.4.6 Contrast (Enhanced)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.6 Contrast (Enhanced)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3291,9 +3248,8 @@
                   href="https://www.w3.org/TR/WCAG21/#low-or-no-background-audio"
                   target="_blank"
                 >
-                  1.4.7 Low or No Background Audio
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.7 Low or No Background Audio<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3317,9 +3273,8 @@
                   href="https://www.w3.org/TR/WCAG21/#visual-presentation"
                   target="_blank"
                 >
-                  1.4.8 Visual Presentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.8 Visual Presentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3354,9 +3309,8 @@
                   href="https://www.w3.org/TR/WCAG21/#images-of-text-no-exception"
                   target="_blank"
                 >
-                  1.4.9 Images of Text (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.9 Images of Text (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3387,9 +3341,8 @@
                   href="https://www.w3.org/TR/WCAG21/#keyboard-no-exception"
                   target="_blank"
                 >
-                  2.1.3 Keyboard (No Exception)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.3 Keyboard (No Exception)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3422,9 +3375,8 @@
                   href="https://www.w3.org/TR/WCAG21/#no-timing"
                   target="_blank"
                 >
-                  2.2.3 No Timing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.3 No Timing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3458,9 +3410,8 @@
                   href="https://www.w3.org/TR/WCAG21/#interruptions"
                   target="_blank"
                 >
-                  2.2.4 Interruptions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.4 Interruptions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3484,9 +3435,8 @@
                   href="https://www.w3.org/TR/WCAG21/#re-authenticating"
                   target="_blank"
                 >
-                  2.2.5 Re-authenticating
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.5 Re-authenticating<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3510,9 +3460,8 @@
                   href="https://www.w3.org/TR/WCAG21/#timeouts"
                   target="_blank"
                 >
-                  2.2.6 Timeouts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.6 Timeouts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3529,9 +3478,8 @@
                   href="https://www.w3.org/TR/WCAG21/#three-flashes"
                   target="_blank"
                 >
-                  2.3.2 Three Flashes
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.2 Three Flashes<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3562,9 +3510,8 @@
                   href="https://www.w3.org/TR/WCAG21/#animation-from-interactions"
                   target="_blank"
                 >
-                  2.3.3 Animation from Interactions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.3 Animation from Interactions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3581,9 +3528,8 @@
                   href="https://www.w3.org/TR/WCAG21/#location"
                   target="_blank"
                 >
-                  2.4.8 Location
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.8 Location<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3617,9 +3563,8 @@
                   href="https://www.w3.org/TR/WCAG21/#link-purpose-link-only"
                   target="_blank"
                 >
-                  2.4.9 Link Purpose (Link Only)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.9 Link Purpose (Link Only)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3653,9 +3598,8 @@
                   href="https://www.w3.org/TR/WCAG21/#section-headings"
                   target="_blank"
                 >
-                  2.4.10 Section Headings
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.10 Section Headings<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3689,9 +3633,8 @@
                   href="https://www.w3.org/TR/WCAG21/#target-size"
                   target="_blank"
                 >
-                  2.5.5 Target Size
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.5 Target Size<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3708,9 +3651,8 @@
                   href="https://www.w3.org/TR/WCAG21/#concurrent-input-mechanisms"
                   target="_blank"
                 >
-                  2.5.6 Concurrent Input Mechanisms
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.5.6 Concurrent Input Mechanisms<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3727,9 +3669,8 @@
                   href="https://www.w3.org/TR/WCAG21/#unusual-words"
                   target="_blank"
                 >
-                  3.1.3 Unusual Words
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.3 Unusual Words<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3753,9 +3694,8 @@
                   href="https://www.w3.org/TR/WCAG21/#abbreviations"
                   target="_blank"
                 >
-                  3.1.4 Abbreviations
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.4 Abbreviations<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3779,9 +3719,8 @@
                   href="https://www.w3.org/TR/WCAG21/#reading-level"
                   target="_blank"
                 >
-                  3.1.5 Reading Level
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.5 Reading Level<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3805,9 +3744,8 @@
                   href="https://www.w3.org/TR/WCAG21/#pronunciation"
                   target="_blank"
                 >
-                  3.1.6 Pronunciation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.6 Pronunciation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3831,9 +3769,8 @@
                   href="https://www.w3.org/TR/WCAG21/#change-on-request"
                   target="_blank"
                 >
-                  3.2.5 Change on Request
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.5 Change on Request<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3854,9 +3791,8 @@
             <tr id="3.3.5">
               <td>
                 <a href="https://www.w3.org/TR/WCAG21/#help" target="_blank">
-                  3.3.5 Help
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.5 Help<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3880,9 +3816,8 @@
                   href="https://www.w3.org/TR/WCAG21/#error-prevention-all"
                   target="_blank"
                 >
-                  3.3.6 Error Prevention (All)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.6 Error Prevention (All)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3966,9 +3901,8 @@
                   href="https://www.access-board.gov/ict/#302.1"
                   target="_blank"
                 >
-                  302.1 Without Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.1 Without Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3995,9 +3929,8 @@
                   href="https://www.access-board.gov/ict/#302.2"
                   target="_blank"
                 >
-                  302.2 With Limited Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.2 With Limited Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4024,9 +3957,8 @@
                   href="https://www.access-board.gov/ict/#302.3"
                   target="_blank"
                 >
-                  302.3 Without Perception of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.3 Without Perception of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4053,9 +3985,8 @@
                   href="https://www.access-board.gov/ict/#302.4"
                   target="_blank"
                 >
-                  302.4 Without Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.4 Without Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4077,9 +4008,8 @@
                   href="https://www.access-board.gov/ict/#302.5"
                   target="_blank"
                 >
-                  302.5 With Limited Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.5 With Limited Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4101,9 +4031,8 @@
                   href="https://www.access-board.gov/ict/#302.6"
                   target="_blank"
                 >
-                  302.6 Without Speech
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.6 Without Speech<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4125,9 +4054,8 @@
                   href="https://www.access-board.gov/ict/#302.7"
                   target="_blank"
                 >
-                  302.7 With Limited Manipulation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.7 With Limited Manipulation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4157,9 +4085,10 @@
                   href="https://www.access-board.gov/ict/#302.8"
                   target="_blank"
                 >
-                  302.8 With Limited Reach and Strength
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.8 With Limited Reach and Strength<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4189,9 +4118,9 @@
                   href="https://www.access-board.gov/ict/#302.9"
                   target="_blank"
                 >
-                  302.9 With Limited Language, Cognitive, and Learning Abilities
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.9 With Limited Language, Cognitive, and Learning
+                  Abilities<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4308,9 +4237,10 @@
                   href="https://www.access-board.gov/ict/#602.2"
                   target="_blank"
                 >
-                  602.2 Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.2 Accessibility and Compatibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4333,9 +4263,8 @@
                   target="_blank"
                 >
                   602.4 Alternate Formats for Non-Electronic Support
-                  Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  Documentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4357,9 +4286,9 @@
                   href="https://www.access-board.gov/ict/#603.2"
                   target="_blank"
                 >
-                  603.2 Information on Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.2 Information on Accessibility and Compatibility
+                  Features<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4381,9 +4310,10 @@
                   href="https://www.access-board.gov/ict/#603.3"
                   target="_blank"
                 >
-                  603.3 Accommodation of Communication Needs
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.3 Accommodation of Communication Needs<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4405,9 +4335,10 @@
                   href="https://www.access-board.gov/ict/#602.3"
                   target="_blank"
                 >
-                  602.3 Electronic Support Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.3 Electronic Support Documentation<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -4510,16 +4441,14 @@
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >OpenACR<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >GSA<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
             </div>

--- a/openacr/govready-0.9.html
+++ b/openacr/govready-0.9.html
@@ -263,9 +263,10 @@
               <tr>
                 <td>
                   <a href="https://www.w3.org/TR/WCAG20/" target="_blank"
-                    >Web Content Accessibility Guidelines 2.0
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    >Web Content Accessibility Guidelines 2.0<span
+                      class="usa-sr-only"
+                    >
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -281,9 +282,8 @@
                 <td>
                   <a href="https://www.access-board.gov/ict/" target="_blank"
                     >Revised Section 508 standards published January 18, 2017
-                    and corrected January 22, 2018
-                    <span class="usa-sr-only"
-                      >(opens in a new window or tab)</span
+                    and corrected January 22, 2018<span class="usa-sr-only">
+                      (opens in a new window or tab)</span
                     ></a
                   >
                 </td>
@@ -407,9 +407,8 @@
                   href="https://www.w3.org/TR/WCAG20/#text-equiv-all"
                   target="_blank"
                 >
-                  1.1.1 Non-text Content
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.1.1 Non-text Content<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -480,9 +479,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-av-only-alt"
                   target="_blank"
                 >
-                  1.2.1 Audio-only and Video-only (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.1 Audio-only and Video-only (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -524,9 +524,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-captions"
                   target="_blank"
                 >
-                  1.2.2 Captions (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.2 Captions (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -568,9 +567,9 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc"
                   target="_blank"
                 >
-                  1.2.3 Audio Description or Media Alternative (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.3 Audio Description or Media Alternative
+                  (Prerecorded)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -612,9 +611,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-programmatic"
                   target="_blank"
                 >
-                  1.3.1 Info and Relationships
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.1 Info and Relationships<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -680,9 +678,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-sequence"
                   target="_blank"
                 >
-                  1.3.2 Meaningful Sequence
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.2 Meaningful Sequence<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -743,9 +740,8 @@
                   href="https://www.w3.org/TR/WCAG20/#content-structure-separation-understanding"
                   target="_blank"
                 >
-                  1.3.3 Sensory Characteristics
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.3.3 Sensory Characteristics<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -806,9 +802,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-without-color"
                   target="_blank"
                 >
-                  1.4.1 Use of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.1 Use of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -869,9 +864,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-dis-audio"
                   target="_blank"
                 >
-                  1.4.2 Audio Control
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.2 Audio Control<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -913,9 +907,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-keyboard-operable"
                   target="_blank"
                 >
-                  2.1.1 Keyboard
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.1 Keyboard<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -983,9 +976,8 @@
                   href="https://www.w3.org/TR/WCAG20/#keyboard-operation-trapping"
                   target="_blank"
                 >
-                  2.1.2 No Keyboard Trap
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.1.2 No Keyboard Trap<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1049,9 +1041,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-required-behaviors"
                   target="_blank"
                 >
-                  2.2.1 Pause, Stop, Hide
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.1 Pause, Stop, Hide<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1093,9 +1084,8 @@
                   href="https://www.w3.org/TR/WCAG20/#time-limits-pause"
                   target="_blank"
                 >
-                  2.2.2 Timing Adjustable
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.2.2 Timing Adjustable<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1137,9 +1127,10 @@
                   href="https://www.w3.org/TR/WCAG20/#seizure-does-not-violate"
                   target="_blank"
                 >
-                  2.3.1 Three Flashes or Below Threshold
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.3.1 Three Flashes or Below Threshold<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1194,9 +1185,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-skip"
                   target="_blank"
                 >
-                  2.4.1 Bypass Blocks
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.1 Bypass Blocks<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1257,9 +1247,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-title"
                   target="_blank"
                 >
-                  2.4.2 Page Titled
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.2 Page Titled<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1320,9 +1309,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-order"
                   target="_blank"
                 >
-                  2.4.3 Focus Order
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.3 Focus Order<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1392,9 +1380,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-refs"
                   target="_blank"
                 >
-                  2.4.4 Link Purpose (In Context)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.4 Link Purpose (In Context)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1458,9 +1445,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-doc-lang-id"
                   target="_blank"
                 >
-                  3.1.1 Language of Page
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.1 Language of Page<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1527,9 +1513,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-receive-focus"
                   target="_blank"
                 >
-                  3.2.1 On Focus
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.1 On Focus<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1599,9 +1584,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-unpredictable-change"
                   target="_blank"
                 >
-                  3.2.2 On Input
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.2 On Input<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1671,9 +1655,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-identified"
                   target="_blank"
                 >
-                  3.3.1 Error Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.1 Error Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1725,9 +1708,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-cues"
                   target="_blank"
                 >
-                  3.3.2 Labels or Instructions
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.2 Labels or Instructions<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1788,9 +1770,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-parses"
                   target="_blank"
                 >
-                  4.1.1 Parsing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.1 Parsing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1850,9 +1831,8 @@
                   href="https://www.w3.org/TR/WCAG20/#ensure-compat-rsv"
                   target="_blank"
                 >
-                  4.1.2 Name, Role, Value
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  4.1.2 Name, Role, Value<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1952,9 +1932,8 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-real-time-captions"
                   target="_blank"
                 >
-                  1.2.4 Captions (Live)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.4 Captions (Live)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -1990,9 +1969,10 @@
                   href="https://www.w3.org/TR/WCAG20/#media-equiv-audio-desc-only"
                   target="_blank"
                 >
-                  1.2.5 Audio Description (Prerecorded)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.2.5 Audio Description (Prerecorded)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2034,9 +2014,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-contrast"
                   target="_blank"
                 >
-                  1.4.3 Contrast (Minimum)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.3 Contrast (Minimum)<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2110,9 +2089,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-scale"
                   target="_blank"
                 >
-                  1.4.4 Resize text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.4 Resize text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2164,9 +2142,8 @@
                   href="https://www.w3.org/TR/WCAG20/#visual-audio-contrast-text-presentation"
                   target="_blank"
                 >
-                  1.4.5 Images of Text
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  1.4.5 Images of Text<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2208,9 +2185,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-mult-loc"
                   target="_blank"
                 >
-                  2.4.5 Multiple Ways
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.5 Multiple Ways<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2262,9 +2238,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-descriptive"
                   target="_blank"
                 >
-                  2.4.6 Headings and Labels
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.6 Headings and Labels<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2333,9 +2308,8 @@
                   href="https://www.w3.org/TR/WCAG20/#navigation-mechanisms-focus-visible"
                   target="_blank"
                 >
-                  2.4.7 Focus Visible
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  2.4.7 Focus Visible<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2397,9 +2371,8 @@
                   href="https://www.w3.org/TR/WCAG20/#meaning-other-lang-id"
                   target="_blank"
                 >
-                  3.1.2 Language of Parts
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.1.2 Language of Parts<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2458,9 +2431,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-locations"
                   target="_blank"
                 >
-                  3.2.3 Consistent Navigation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.3 Consistent Navigation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2513,9 +2485,8 @@
                   href="https://www.w3.org/TR/WCAG20/#consistent-behavior-consistent-functionality"
                   target="_blank"
                 >
-                  3.2.4 Consistent Identification
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.2.4 Consistent Identification<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2564,9 +2535,8 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-suggestions"
                   target="_blank"
                 >
-                  3.3.3 Error Suggestion
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.3 Error Suggestion<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2608,9 +2578,10 @@
                   href="https://www.w3.org/TR/WCAG20/#minimize-error-reversible"
                   target="_blank"
                 >
-                  3.3.4 Error Prevention (Legal, Financial, Data)
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  3.3.4 Error Prevention (Legal, Financial, Data)<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2726,9 +2697,8 @@
                   href="https://www.access-board.gov/ict/#302.1"
                   target="_blank"
                 >
-                  302.1 Without Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.1 Without Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2759,9 +2729,8 @@
                   href="https://www.access-board.gov/ict/#302.2"
                   target="_blank"
                 >
-                  302.2 With Limited Vision
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.2 With Limited Vision<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2788,9 +2757,8 @@
                   href="https://www.access-board.gov/ict/#302.3"
                   target="_blank"
                 >
-                  302.3 Without Perception of Color
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.3 Without Perception of Color<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2821,9 +2789,8 @@
                   href="https://www.access-board.gov/ict/#302.4"
                   target="_blank"
                 >
-                  302.4 Without Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.4 Without Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2845,9 +2812,8 @@
                   href="https://www.access-board.gov/ict/#302.5"
                   target="_blank"
                 >
-                  302.5 With Limited Hearing
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.5 With Limited Hearing<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2869,9 +2835,8 @@
                   href="https://www.access-board.gov/ict/#302.6"
                   target="_blank"
                 >
-                  302.6 Without Speech
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.6 Without Speech<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2893,9 +2858,8 @@
                   href="https://www.access-board.gov/ict/#302.7"
                   target="_blank"
                 >
-                  302.7 With Limited Manipulation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.7 With Limited Manipulation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2926,9 +2890,10 @@
                   href="https://www.access-board.gov/ict/#302.8"
                   target="_blank"
                 >
-                  302.8 With Limited Reach and Strength
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.8 With Limited Reach and Strength<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -2955,9 +2920,9 @@
                   href="https://www.access-board.gov/ict/#302.9"
                   target="_blank"
                 >
-                  302.9 With Limited Language, Cognitive, and Learning Abilities
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  302.9 With Limited Language, Cognitive, and Learning
+                  Abilities<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3074,9 +3039,10 @@
                   href="https://www.access-board.gov/ict/#602.2"
                   target="_blank"
                 >
-                  602.2 Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  602.2 Accessibility and Compatibility Features<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3099,9 +3065,8 @@
                   target="_blank"
                 >
                   602.4 Alternate Formats for Non-Electronic Support
-                  Documentation
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  Documentation<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3123,9 +3088,9 @@
                   href="https://www.access-board.gov/ict/#603.2"
                   target="_blank"
                 >
-                  603.2 Information on Accessibility and Compatibility Features
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.2 Information on Accessibility and Compatibility
+                  Features<span class="usa-sr-only">
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3147,9 +3112,10 @@
                   href="https://www.access-board.gov/ict/#603.3"
                   target="_blank"
                 >
-                  603.3 Accommodation of Communication Needs
-                  <span class="usa-sr-only"
-                    >(opens in a new window or tab)</span
+                  603.3 Accommodation of Communication Needs<span
+                    class="usa-sr-only"
+                  >
+                    (opens in a new window or tab)</span
                   >
                 </a>
               </td>
@@ -3201,16 +3167,14 @@
           <div class="grid-row grid-gap">
             <div class="grid-col">
               <a href="https://github.com/GSA/openacr" target="_blank"
-                >OpenACR
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >OpenACR<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >
               is a format maintained by the
               <a href="https://gsa.gov/" target="_blank"
-                >GSA
-                <span class="usa-sr-only"
-                  >(opens in a new window or tab)</span
+                >GSA<span class="usa-sr-only">
+                  (opens in a new window or tab)</span
                 ></a
               >. The content is the responsibility of the author.
             </div>

--- a/templates/openacr-html-0.1.0.handlebars
+++ b/templates/openacr-html-0.1.0.handlebars
@@ -97,7 +97,7 @@
           <tbody>
             {{#each catalog.standards as |catalog-standard|}}
               <tr>
-                <td><a href="{{catalog-standard.url}}" target="_blank">{{catalog-standard.label}} <span class="usa-sr-only">(opens in a new window or tab)</span></a></td>
+                <td><a href="{{catalog-standard.url}}" target="_blank">{{catalog-standard.label}}<span class="usa-sr-only"> (opens in a new window or tab)</span></a></td>
                 <td>{{standardsIncluded catalog-standard.chapters}}</td>
               </tr>
             {{/each}}
@@ -152,7 +152,7 @@
                       <tr id="{{data-criteria.num}}">
                         <td>
                           <a href="{{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}}" target="_blank">
-                            {{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}} <span class="usa-sr-only">(opens in a new window or tab)</span>
+                            {{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}<span class="usa-sr-only"> (opens in a new window or tab)</span>
                           </a>
                         </td>
                         <td>
@@ -221,7 +221,7 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="grid-col">
-            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="usa-sr-only">(opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA <span class="usa-sr-only">(opens in a new window or tab)</span></a>. The content is the responsibility of the author.
+            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="usa-sr-only"> (opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA<span class="usa-sr-only"> (opens in a new window or tab)</span></a>. The content is the responsibility of the author.
           </div>
           <div class="grid-col">
             This content is licensed under a {{license}}.

--- a/templates/openacr-simple-html-0.1.0.handlebars
+++ b/templates/openacr-simple-html-0.1.0.handlebars
@@ -206,7 +206,7 @@
           <tbody>
             {{#each catalog.standards as |catalog-standard|}}
               <tr>
-                <td><a href="{{catalog-standard.url}}" target="_blank">{{catalog-standard.label}} <span class="usa-sr-only">(opens in a new window or tab)</span></a></td>
+                <td><a href="{{catalog-standard.url}}" target="_blank">{{catalog-standard.label}}<span class="usa-sr-only"> (opens in a new window or tab)</span></a></td>
                 <td>{{standardsIncluded catalog-standard.chapters}}</td>
               </tr>
             {{/each}}
@@ -261,7 +261,7 @@
                       <tr id="{{data-criteria.num}}">
                         <td>
                           <a href="{{catalogCriteriaURL catalog-chapter.id data-criteria.num catalog-standard.url}}" target="_blank">
-                            {{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}} <span class="usa-sr-only">(opens in a new window or tab)</span>
+                            {{data-criteria.num}} {{catalogCriteriaLabel catalog-chapter.id data-criteria.num}}<span class="usa-sr-only"> (opens in a new window or tab)</span>
                           </a>
                         </td>
                         <td>
@@ -330,7 +330,7 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="grid-col">
-            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="usa-sr-only">(opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA <span class="usa-sr-only">(opens in a new window or tab)</span></a>. The content is the responsibility of the author.
+            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="usa-sr-only"> (opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA<span class="usa-sr-only"> (opens in a new window or tab)</span></a>. The content is the responsibility of the author.
           </div>
           <div class="grid-col">
             This content is licensed under a {{license}}.

--- a/tests/examples/valid.html
+++ b/tests/examples/valid.html
@@ -206,11 +206,11 @@
           </thead>
           <tbody>
               <tr>
-                <td><a href="https://www.w3.org/TR/WCAG20/" target="_blank">Web Content Accessibility Guidelines 2.0 <span class="usa-sr-only">(opens in a new window or tab)</span></a></td>
+                <td><a href="https://www.w3.org/TR/WCAG20/" target="_blank">Web Content Accessibility Guidelines 2.0<span class="usa-sr-only"> (opens in a new window or tab)</span></a></td>
                 <td><ul><li>Table 1: Success Criteria, Level A</li><li>Table 2: Success Criteria, Level AA</li><li>Table 3: Success Criteria, Level AAA</li></ul></td>
               </tr>
               <tr>
-                <td><a href="https://www.access-board.gov/ict/" target="_blank">Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018 <span class="usa-sr-only">(opens in a new window or tab)</span></a></td>
+                <td><a href="https://www.access-board.gov/ict/" target="_blank">Revised Section 508 standards published January 18, 2017 and corrected January 22, 2018<span class="usa-sr-only"> (opens in a new window or tab)</span></a></td>
                 <td><ul><li>Chapter 3: Functional Performance Criteria (FPC)</li><li>Chapter 4: Hardware</li><li>Chapter 5: Software</li><li>Chapter 6: Support Documentation and Services</li></ul></td>
               </tr>
           </tbody>
@@ -296,7 +296,7 @@
                       <tr id="1.1.1">
                         <td>
                           <a href="https://www.w3.org/TR/WCAG20/#text-equiv-all" target="_blank">
-                            1.1.1 Non-text Content <span class="usa-sr-only">(opens in a new window or tab)</span>
+                            1.1.1 Non-text Content<span class="usa-sr-only"> (opens in a new window or tab)</span>
                           </a>
                         </td>
                         <td>
@@ -321,7 +321,7 @@
                       <tr id="1.2.2">
                         <td>
                           <a href="https://www.w3.org/TR/WCAG20/#media-equiv-captions" target="_blank">
-                            1.2.2 Captions (Prerecorded) <span class="usa-sr-only">(opens in a new window or tab)</span>
+                            1.2.2 Captions (Prerecorded)<span class="usa-sr-only"> (opens in a new window or tab)</span>
                           </a>
                         </td>
                         <td>
@@ -514,7 +514,7 @@
       <div class="grid-container">
         <div class="grid-row grid-gap">
           <div class="grid-col">
-            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR <span class="usa-sr-only">(opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA <span class="usa-sr-only">(opens in a new window or tab)</span></a>. The content is the responsibility of the author.
+            <a href="https://github.com/GSA/openacr" target="_blank">OpenACR<span class="usa-sr-only"> (opens in a new window or tab)</span></a> is a format maintained by the <a href="https://gsa.gov/" target="_blank">GSA<span class="usa-sr-only"> (opens in a new window or tab)</span></a>. The content is the responsibility of the author.
           </div>
           <div class="grid-col">
             This content is licensed under a <a href="https://creativecommons.org/licenses/by/4.0/legalcode" target="_blank">Creative Commons Attribution 4.0 International<span class="usa-sr-only"> (opens in a new window or tab)</span></a>.


### PR DESCRIPTION
Same changes as https://github.com/CivicActions/openacr-editor/pull/18